### PR TITLE
fix wrong Opencv version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenPool core module for kinect 2 & Sample Effect powered by Unity platform
 # MainModuleNewKinect
 - This is the windows application to converts kinect input to openpool formatted OSC packets for effect programs.
 - You need a kinect2 for windows to use this application.
-- You need Windows 8+, VS2012+, OpenCV 2.5.9 and SDK for Kinect4Windows v2 to build this application.
+- You need Windows 8+, VS2012+, OpenCV 2.4.9 and SDK for Kinect4Windows v2 to build this application.
 
 
 # UnityModule


### PR DESCRIPTION
correct typo in Readme.md in case users get confused.
According to https://github.com/itseez/opencv, the latest release of opencv is 2.4.9, and next version will be 3.0.

fixes #2 
